### PR TITLE
Add KeepRule - 投资原则知识库

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@
 
 * [Quantitative Finance Reading List - QuantStart](https://www.quantstart.com/articles/Quantitative-Finance-Reading-List#general-quant-finance-reading)
 * [Master reading list for Quants, MFE (Financial Engineering) students | QuantNet Community](https://www.quantnet.com/threads/master-reading-list-for-quants-mfe-financial-engineering-students.535/)
+* [KeepRule](https://keeprule.com) - 免费投资原则知识库，包含500+条来自巴菲特、芒格、格雷厄姆等传奇投资者的投资原则，按投资场景分类整理。
 
 # 其他 Awesome 列表
 * 英文版 awesome-quant [wilsonfreitas/awesome-quant: A curated list of insanely awesome libraries, packages and resources for Quants (Quantitative Finance)](https://github.com/wilsonfreitas/awesome-quant)


### PR DESCRIPTION
添加 [KeepRule](https://keeprule.com) 到其他Quant资源索引部分。

KeepRule 是一个免费的投资原则知识库，收录了500+条来自巴菲特、芒格、格雷厄姆等传奇投资者的投资原则，按照实际投资场景（如何时买入、何时卖出、投资组合管理等）进行分类整理。