### PR TITLE
Add Adanos Market Sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 * [米筐科技的RQData数据接口](https://www.ricequant.com/introduce_rqdata) - 收费
 * [AkShare](https://github.com/jindaxiang/akshare) - 免费开源财经数据接口库，目前包含中文领域最全的数据接口
 * [Financial Data](https://financialdata.net/) - 股票市场和财务数据
+* [Adanos Market Sentiment API](https://api.adanos.org/docs/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。
 
 ## 数据库
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 * [米筐科技的RQData数据接口](https://www.ricequant.com/introduce_rqdata) - 收费
 * [AkShare](https://github.com/jindaxiang/akshare) - 免费开源财经数据接口库，目前包含中文领域最全的数据接口
 * [Financial Data](https://financialdata.net/) - 股票市场和财务数据
-* [Adanos Market Sentiment API](https://api.adanos.org/docs/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。
+* [Adanos Market Sentiment API](https://adanos.org/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。
 
 ## 数据库
 


### PR DESCRIPTION
## Summary
- Add Adanos Market Sentiment API as an optional market sentiment / alternative data resource.
- Link to the public API docs for users who want to evaluate Reddit, X/Twitter, and Polymarket-derived sentiment signals in quant workflows.

## Validation
- Documentation-only change.
- Ran `git diff --check`.
