### PR TITLE
Add TrendRider Strategy to 策略 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 * [RiceQuant米筐量化社区 2016年4月以来优秀策略与研究汇总](https://www.ricequant.com/community/topic/1863//3)
 * [雪球选股](https://xueqiu.com/9796081404)
 * [botvs/strategies: 用Javascript OR Python进行量化交易](https://github.com/botvs/strategies)
+* [TrendRider Strategy](https://github.com/darkvolg/trendrider-strategy) - 开源的Freqtrade加密货币交易策略 (Bybit), 具有创新的级联止损退出逻辑 (cascading early-loss exit: -1.5%@2h, BE@4h, +0.5%@8h, +1%@16h, forced 24h). 回测结果对比固定24小时超时: +69% 净收益, -77% 最大回撤. 多时间框架入场 BTC/ETH/SOL + 15 种山寨币. 实时 dry-run 数据流: [trendrider.net/live](https://trendrider.net/live). MIT 许可.
 
 ## 回测
 * [Zipline](https://github.com/quantopian/zipline) - 一个Python的回测框架


### PR DESCRIPTION
## 什么 / What

在 `策略` 部分添加 **TrendRider Strategy** — 一个开源的基于Freqtrade的加密货币交易策略，具有新颖的级联止损退出逻辑和公开的实时测试数据面板。

Adding **TrendRider Strategy** to the `策略` (Strategies) section — an open-source Freqtrade-based crypto trading strategy with a novel cascading early-loss exit ladder and a **public live dry-run dashboard**.

![TrendRider banner](https://raw.githubusercontent.com/darkvolg/trendrider-strategy/master/banner.png)

## 为什么适合这个列表 / Why it fits this list

- **开源 / Open source** — MIT license, single Python file (~745 lines) for the Freqtrade framework
- **交易所 / Exchange:** Bybit USDT-perp (BTC/ETH/SOL + 15 altcoins, 1h timeframe)
- **回测可重现 / Reproducible backtest** — README中包含准确的 `freqtrade backtesting` 命令，20分钟内可以验证所有数字
- **实时 dry-run 数据 / Live dry-run proof** — [trendrider.net/live](https://trendrider.net/live) 直接从 Freqtrade REST API 流式传输实时数据 (胜率、亏损、净值曲线、回撤)。不是截图。

## 核心技术贡献 / Core technical contribution

策略的新颖点是 `custom_exit` 中的**级联早期止损退出** — 随着交易时间的增加，可接受的退出价格向上棘轮，而不是使用固定的时间止损：

The strategy's novel piece is a **cascading early-loss exit ladder** in `custom_exit` that ratchets the acceptable exit price upward with trade age:

| 交易时间 / Trade age | 可接受退出 / Acceptable exit |
|---------|---------------|
| 2h      | -1.5%         |
| 4h      | break-even    |
| 8h      | +0.5%         |
| 16h     | +1.0%         |
| 24h     | forced close  |

**回测结果 / Backtest delta** (vs 固定24小时超时, 相同数据集、相同 buy_params、1h TF、30 天):

- **+69% 净收益 / net profit**
- **−77% 最大回撤 / max drawdown**
- 67.9% 胜率 / win rate across 10,000+ simulated trades
- 1.42% 最大回撤绝对值 / max DD absolute

## 添加的条目 / Entry added

在 `## 策略` 部分，添加在 `botvs/strategies` 后面：

```markdown
* [TrendRider Strategy](https://github.com/darkvolg/trendrider-strategy) - 开源的Freqtrade加密货币交易策略 (Bybit), 具有创新的级联止损退出逻辑 (cascading early-loss exit: -1.5%@2h, BE@4h, +0.5%@8h, +1%@16h, forced 24h). 回测结果对比固定24小时超时: +69% 净收益, -77% 最大回撤. 多时间框架入场 BTC/ETH/SOL + 15 种山寨币. 实时 dry-run 数据流: [trendrider.net/live](https://trendrider.net/live). MIT 许可.
```

## 仓库 / Repo

- 代码 / Code: https://github.com/darkvolg/trendrider-strategy
- 实时数据 / Live: https://trendrider.net/live

谢谢维护这个列表！ Thanks for maintaining this list.