### PR TITLE
Add FXMacroData to 数据源

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 * [米筐科技的RQData数据接口](https://www.ricequant.com/introduce_rqdata) - 收费
 * [AkShare](https://github.com/jindaxiang/akshare) - 免费开源财经数据接口库，目前包含中文领域最全的数据接口
 * [Financial Data](https://financialdata.net/) - 股票市场和财务数据
+* [FXMacroData](https://fxmacrodata.com) - 实时外汇宏观经济数据 API，提供 18 种货币的央行公告、利率、通胀、就业和 GDP 数据。支持 MCP 服务器和 OAuth。[GitHub](https://github.com/fxmacrodata/fxmacrodata) | [PyPI](https://pypi.org/project/fxmacrodata/)
 * [Adanos Market Sentiment API](https://adanos.org/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。
 
 ## 数据库


### PR DESCRIPTION
Adds [FXMacroData](https://fxmacrodata.com) to the **数据源** (Data Source) section.

FXMacroData is a real-time forex macroeconomic data API serving central bank announcements, policy rates, inflation, employment, and GDP data for 18 currencies. It includes an MCP server and OAuth support.

- **Website**: https://fxmacrodata.com
- **PyPI**: https://pypi.org/project/fxmacrodata/
- **GitHub**: https://github.com/fxmacrodata/fxmacrodata
- **API Docs**: https://fxmacrodata.com/api-docs