### PR TITLE
Add 13F Insight to 数据源 (Data Sources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 * [Financial Data](https://financialdata.net/) - 股票市场和财务数据
 * [FXMacroData](https://fxmacrodata.com) - 实时外汇宏观经济数据 API，提供 18 种货币的央行公告、利率、通胀、就业和 GDP 数据。支持 MCP 服务器和 OAuth。[GitHub](https://github.com/fxmacrodata/fxmacrodata) | [PyPI](https://pypi.org/project/fxmacrodata/)
 * [Adanos Market Sentiment API](https://adanos.org/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。
+* [13F Insight](https://13finsight.com) - AI 驱动的美国机构持仓追踪平台，覆盖 380K+ 13F 持仓报告、480K+ 13D/G 激进投资者申报和 437万+ Form 4 内部人交易数据，内嵌 AI Agent 支持自然语言查询。
 
 ## 数据库
 


### PR DESCRIPTION
## 添加 13F Insight 到数据源

**网站**：https://13finsight.com

**描述**：AI 驱动的美国机构持仓追踪平台，覆盖 SEC 三类核心申报文件：

- **13F 持仓报告**：380K+ 份，追踪 1999 年至今的对冲基金 / 机构持仓变动
- **13D/G 激进投资者申报**：480K+ 份，追踪 1994 年至今
- **Form 4 内部人交易**：437 万+ 条，追踪 2003 年至今

**核心功能**：
- 跨实体检索（基金 / 股票 / 内部人）+ 持仓变动 diff 对比
- 每个基金/股票/申报页面内嵌 AI Agent，支持自然语言查询
- 编辑研究中心（/research、/learn、/news）提供数据驱动分析文章

**用户群体**：量化研究者、零售投资者、金融记者、机构数据消费者

**定价**：免费注册（每日 5 次 AI 查询）；付费解锁无限访问

与已收录的 Financial Data、FXMacroData、Adanos Market Sentiment API 等工具互补，专注于 SEC 机构申报数据这一细分方向。
