### PR TITLE
添加 finlight (实时财经新闻 API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 * [FXMacroData](https://fxmacrodata.com) - 实时外汇宏观经济数据 API，提供 18 种货币的央行公告、利率、通胀、就业和 GDP 数据。支持 MCP 服务器和 OAuth。[GitHub](https://github.com/fxmacrodata/fxmacrodata) | [PyPI](https://pypi.org/project/fxmacrodata/)
 * [Adanos Market Sentiment API](https://adanos.org/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。
 * [13F Insight](https://13finsight.com) - AI 驱动的美国机构持仓追踪平台，覆盖 380K+ 13F 持仓报告、480K+ 13D/G 激进投资者申报和 437万+ Form 4 内部人交易数据，内嵌 AI Agent 支持自然语言查询。
+* [finlight](https://finlight.me/) - 实时财经新闻 API，聚焦全球金融、地缘政治与市场新闻，提供 REST 和 WebSocket 接口，内置实体识别与情绪分析。[GitHub](https://github.com/jubeiargh/finlight-client-py) | [PyPI](https://pypi.org/project/finlight-client/)
 
 ## 数据库
 


### PR DESCRIPTION
添加 finlight：实时财经新闻 API，覆盖全球金融、地缘政治与市场新闻，REST 和 WebSocket 接口，内置实体识别（股票代码）与情绪分析。开源 Python 和 TypeScript SDK（MIT）。与现有数据源互补：聚焦海外与地缘政治新闻数据，而非 A 股行情。 Adds finlight, a real-time news API for global finance, markets and geopolitics with entity and sentiment enrichment, REST + WebSocket, open-source Python/TypeScript SDKs (MIT).