### PR TITLE
Add ashare-lake to 数据源

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 * [JoinQuant/jqdatasdk](https://github.com/JoinQuant/jqdatasdk) - jqdatasdk是提供给用户获取聚宽金融数据的SDK
 * [米筐科技的RQData数据接口](https://www.ricequant.com/introduce_rqdata) - 收费
 * [AkShare](https://github.com/jindaxiang/akshare) - 免费开源财经数据接口库，目前包含中文领域最全的数据接口
-* [ashare-lake](https://github.com/rootSunc/ashare-lake) - 本地 A 股研究数据底座：整合多源行情与基本面，可持续日更，把一次性取数沉淀为可长期复用的数据资产
+* [ashare-lake](https://github.com/rootSunc/ashare-lake) - 开源 A 股本地数据湖，覆盖股票行情、大宗期货、基本面、资金、结构、宏观、舆情、风控等全套量化数据，支持多源整合与日更
 * [Financial Data](https://financialdata.net/) - 股票市场和财务数据
 * [FXMacroData](https://fxmacrodata.com) - 实时外汇宏观经济数据 API，提供 18 种货币的央行公告、利率、通胀、就业和 GDP 数据。支持 MCP 服务器和 OAuth。[GitHub](https://github.com/fxmacrodata/fxmacrodata) | [PyPI](https://pypi.org/project/fxmacrodata/)
 * [Adanos Market Sentiment API](https://adanos.org/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 * [JoinQuant/jqdatasdk](https://github.com/JoinQuant/jqdatasdk) - jqdatasdk是提供给用户获取聚宽金融数据的SDK
 * [米筐科技的RQData数据接口](https://www.ricequant.com/introduce_rqdata) - 收费
 * [AkShare](https://github.com/jindaxiang/akshare) - 免费开源财经数据接口库，目前包含中文领域最全的数据接口
-* [ashare-lake](https://github.com/rootSunc/ashare-lake) - 本地可日更、可溯源的 A 股数据湖；多源编排落成 curated Parquet，支持 DuckDB / Polars / `load()` 查询
+* [ashare-lake](https://github.com/rootSunc/ashare-lake) - 本地 A 股研究数据底座：整合多源行情与基本面，可持续日更，把一次性取数沉淀为可长期复用的数据资产
 * [Financial Data](https://financialdata.net/) - 股票市场和财务数据
 * [FXMacroData](https://fxmacrodata.com) - 实时外汇宏观经济数据 API，提供 18 种货币的央行公告、利率、通胀、就业和 GDP 数据。支持 MCP 服务器和 OAuth。[GitHub](https://github.com/fxmacrodata/fxmacrodata) | [PyPI](https://pypi.org/project/fxmacrodata/)
 * [Adanos Market Sentiment API](https://adanos.org/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 * [JoinQuant/jqdatasdk](https://github.com/JoinQuant/jqdatasdk) - jqdatasdk是提供给用户获取聚宽金融数据的SDK
 * [米筐科技的RQData数据接口](https://www.ricequant.com/introduce_rqdata) - 收费
 * [AkShare](https://github.com/jindaxiang/akshare) - 免费开源财经数据接口库，目前包含中文领域最全的数据接口
+* [ashare-lake](https://github.com/rootSunc/ashare-lake) - 本地可日更、可溯源的 A 股数据湖；多源编排落成 curated Parquet，支持 DuckDB / Polars / `load()` 查询
 * [Financial Data](https://financialdata.net/) - 股票市场和财务数据
 * [FXMacroData](https://fxmacrodata.com) - 实时外汇宏观经济数据 API，提供 18 种货币的央行公告、利率、通胀、就业和 GDP 数据。支持 MCP 服务器和 OAuth。[GitHub](https://github.com/fxmacrodata/fxmacrodata) | [PyPI](https://pypi.org/project/fxmacrodata/)
 * [Adanos Market Sentiment API](https://adanos.org/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。


### PR DESCRIPTION
## Summary
- 在「数据源」分类中新增 [ashare-lake](https://github.com/rootSunc/ashare-lake)
- 开源 A 股本地数据湖，覆盖股票行情、大宗期货、基本面、资金、结构、宏观、舆情、风控等全套量化数据，支持多源整合与日更

## 补充说明
- GitHub：https://github.com/rootSunc/ashare-lake
- PyPI：`pip install ashare-lake`
- 与 TuShare / AkShare 等接口库不同：不只提供取数接口，而是把多源数据整合并日更到本地，形成可直接用于研究的完整数据源