### PR TITLE
在 Python 库中加入 Jacobian

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 * [ffn](http://pmorissette.github.io/ffn/quick.html) - 绩效评估
 * [ta-lib: Python wrapper for TA-Lib (http://ta-lib.org/).](https://github.com/mrjbq7/ta-lib) - 技术指标
 * [StatsModels: Statistics in Python — statsmodels documentation](http://statsmodels.sourceforge.net/) - 常用统计模型
+* [morluto/jacobian](https://github.com/morluto/jacobian) - 面向可组合数学的 MCP 服务器、CLI 和 Python 库，可为量化研究中的线性代数、图算法和多项式计算提供精确、可复用的数学基础。
 * [arch: ARCH models in Python](https://github.com/bashtage/arch) - 时间序列
 * [pyfolio: Portfolio and risk analytics in Python](https://github.com/quantopian/pyfolio) - 组合风险评估
 * [twosigma/flint: A Time Series Library for Apache Spark](https://github.com/twosigma/flint) - Apache Spark上的时间序列库


### PR DESCRIPTION
在“编程 / Python / 库”分类中加入 Jacobian。仅新增 README.md 一行，未修改其他内容。

项目简介：Jacobian 是一个面向可组合数学的 MCP 服务器、CLI 和 Python 库，支持多项式映射、线性代数与图算法的精确计算和猜想检验。

收录理由：量化研究中的因子、组合、图结构和数值研究都依赖可复用的数学计算基础。Jacobian 不提供交易信号或行情数据，而是提供可独立调用的精确线性代数、多项式和图算法能力，因此放在 Python 库分类中。

安装：npx -y jacobian mcp

许可证：MIT

验证：

- git diff --check