### PR TITLE
在回测分类加入 ml-quant-trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 * [QUANTAXIS](https://github.com/yutiansut/QUANTAXIS) - QUANTAXIS 量化金融策略框架 - 中小型策略团队解决方案
 * [Hikyuu](http://hikyuu.org) - 基于Python/C++的开源量化交易研究框架
 * [StarQuant](https://github.com/physercoe/starquant) - 基于Python/C++的综合量化交易回测系统/平台
+* [ml-quant-trading](https://github.com/initial-d/ml-quant-trading) - 基于 PyTorch 的多因子量化研究框架，包含 213 维因子、涨跌停与停牌偏差修正、机器学习基线、组合优化、含成本向量化回测及可复现公开数据验证
 * [finclaw](https://github.com/NeuZhou/finclaw) - AI驱动的量化交易引擎，484个内置alpha因子，遗传算法策略进化，walk-forward回测和模拟交易
 * [TraderHarness](https://github.com/HephaestLab/TraderHarness) - 抗数据污染的A股LLM交易Agent回测环境：全出口时点掩码、日期/公司确定性匿名化、分钟级渐进撮合、指纹回放与全保真轨迹导出（SFT数据合成）
 


### PR DESCRIPTION
本 PR 在「回测」分类加入 ml-quant-trading。

收录理由：

- 面向 A 股多因子研究，覆盖 213 维因子、涨跌停与停牌偏差修正、ML 基线、组合优化和含成本向量化回测
- 提供 Synthetic、AkShare、Baostock 和 yfinance 路径，其中 Synthetic 与 AkShare 可零账号运行
- 有公开论文、CI、测试、因子手册、Research Card、公开数据验证及独立贡献者复现记录
- MIT 开源，近期持续维护

为避免误导，条目只描述研究与回测能力，不包含任何收益或实盘承诺。

利益关系说明：我是该项目的作者和维护者。