### PR TITLE
Fix dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 ## 量化交易平台
 
 * [JoinQuant聚宽量化交易平台](https://www.joinquant.com/) - 一个基于Python的在线量化交易平台
-* [优矿 - 通联量化实验室](https://uqer.io/home/) - 一个基于Python的在线量化交易平台
+* [优矿 - 通联量化实验室](https://uqer.datayes.com/) - 一个基于Python的在线量化交易平台
 * [Ricequant 量化交易平台](https://www.ricequant.com/) - 支持Python和Java的在线量化交易平台
 * [掘金量化](http://www.myquant.cn/) - 支持C/C++、C#、MATLAB、Python和R的量化交易平台
 * [Auto-Trader](http://www.atrader.com.cn/portal.php) - 基于MATLAB的量化交易平台
@@ -78,7 +78,7 @@
 ## 策略
 * [JoinQuant聚宽: 量化学习资料、经典交易策略、Python入门 - 雪球](https://xueqiu.com/8287840120/65009358)
 * [myquant/strategy: 掘金策略集锦](https://github.com/myquant/strategy)
-* [优矿社区内容索引](https://uqer.io/community/share/58243e7d228e5b91df6d5d19)
+* [优矿社区内容索引](https://uqer.datayes.com/community/share/58243e7d228e5b91df6d5d19)
 * [RiceQuant米筐量化社区 2016年4月以来优秀策略与研究汇总](https://www.ricequant.com/community/topic/1863//3)
 * [雪球选股](https://xueqiu.com/9796081404)
 * [botvs/strategies: 用Javascript OR Python进行量化交易](https://github.com/botvs/strategies)
@@ -172,7 +172,7 @@
 ### Julia
 #### 教程
 * [Learning Julia](http://julialang.org/learning/) - 官方整理
-* [QUANTITATIVE ECONOMICS with Julia](http://quant-econ.net/_static/pdfs/jl-quant-econ.pdf) - 经济学诺奖获得者Thomas Sargent教你[Julia](http://julialang.org/)在量化经济的应用。
+* [QUANTITATIVE ECONOMICS with Julia](https://julia.quantecon.org/) - 经济学诺奖获得者Thomas Sargent教你[Julia](http://julialang.org/)在量化经济的应用。
 
 #### 库
 * [Quantitative Finance in Julia](https://github.com/JuliaQuant) - 多数为正在实现中，感兴趣的可以参与
@@ -189,10 +189,9 @@
 ## 论坛
 * [Quantitative Finance StackExchange](http://quant.stackexchange.com/) -  stackexchange 系列的 quant 论坛
 * [JoinQuant社区](https://www.joinquant.com/community) - JoinQuant社区
-* [优矿社区](https://uqer.io/community/list) - 优矿社区
+* [优矿社区](https://uqer.datayes.com/community/list) - 优矿社区
 * [RiceQuant量化社区](https://www.ricequant.com/community/) - RiceQuant量化社区
-* [掘金量化社区](http://forum.myquant.cn/) - 掘金量化社区
-* [清华大学学生经济金融论坛](http://forum.thuquant.com/) - 清华大学学生金融数据与量化投资协会主办
+* [掘金量化社区](https://bbs.myquant.cn/) - 掘金量化社区
 
 ## 书籍
 * [My Life as a Quant: Reflections on Physics and Finance](http://www.amazon.com/My-Life-Quant-Reflections-Physics/dp/0470192739) - In My Life as a Quant, Emanuel Derman relives his exciting journey as one of the first high-energy particle physicists to migrate to Wall Street.


### PR DESCRIPTION
Link-checked the README and fixed what is confirmed dead. Every dead URL was re-verified with curl (browser UA; NXDOMAIN double-checked via 8.8.8.8), and every replacement URL returns HTTP 200.

- `http://forum.myquant.cn/` → `https://bbs.myquant.cn/`
  - Old forum host returns 404. Official community moved to bbs.myquant.cn: HTTP 200 with title '掘金量化社区-MYQUANT' — exactly the same community named in the entry.
- removed entry with `http://forum.thuquant.com/`
  - curl 000 and dig @8.8.8.8 returns nothing (NXDOMAIN). The student-association forum of the repo owner (thuquant) has no successor address findable; dead community entry in a curated list — remove.
- `http://quant-econ.net/_static/pdfs/jl-quant-econ.pdf` → `https://julia.quantecon.org/`
  - quant-econ.net is NXDOMAIN (dig empty). The Sargent/Stachurski lectures moved to quantecon.org; https://julia.quantecon.org/ returns HTTP 200 with title 'Quantitative Economics with Julia' — the same work's official current home.
- `https://uqer.io/community/list` → `https://uqer.datayes.com/community/list`
  - uqer.io is NXDOMAIN (dig empty). 优矿 officially moved to uqer.datayes.com (DataYes); /community/list returns HTTP 200 (redirects to /v3/community/list) with title '优矿' — same platform community.
- `https://uqer.io/community/share/58243e7d228e5b91df6d5d19` → `https://uqer.datayes.com/community/share/58243e7d228e5b91df6d5d19`
  - uqer.io is NXDOMAIN; same post id on the platform's official new domain returns HTTP 200 (redirects to /v3/community/share/<id>). Caveat: page is a login-gated SPA so post content could not be confirmed anonymously; a Wayback capture of the original URL (20180218174928) confirms the post existed at this id.
- `https://uqer.io/home/` → `https://uqer.datayes.com/`
  - uqer.io is NXDOMAIN (dig empty). The 优矿 quant platform now lives at uqer.datayes.com: HTTP 200, title '优矿' — same product's official current home.

Happy to adjust or split this if you'd prefer a different fix for any item.