### PR TITLE
在数据源分类中加入 0xArchive

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 * [13F Insight](https://13finsight.com) - AI 驱动的美国机构持仓追踪平台，覆盖 380K+ 13F 持仓报告、480K+ 13D/G 激进投资者申报和 437万+ Form 4 内部人交易数据，内嵌 AI Agent 支持自然语言查询。
 * [finlight](https://finlight.me/) - 实时财经新闻 API，聚焦全球金融、地缘政治与市场新闻，提供 REST 和 WebSocket 接口，内置实体识别与情绪分析。[GitHub](https://github.com/jubeiargh/finlight-client-py) | [PyPI](https://pypi.org/project/finlight-client/)
 * [stock-analysis](https://github.com/AdvancingTitans/stock-analysis) - 面向 A股、港股、美股和基金的证据驱动复盘 CLI，可生成 Markdown 报告和 JSON Evidence Packs，便于 AI Agent 审计与复用。
+* [0xArchive](https://0xarchive.io/) - 提供 Hyperliquid 和 Lighter 的实时与历史市场数据 API，支持 REST 和 WebSocket。
 
 ## 数据库
 


### PR DESCRIPTION
在 `数据源` 分类中加入 0xArchive。

* **链接：** https://0xarchive.io/
* **简介：** 提供 Hyperliquid 和 Lighter 的实时与历史市场数据 API，支持 REST 和 WebSocket。
* **免费层：** 提供永久免费层，无需信用卡。

**利益披露：本人和 0xArchive 有关联。** 如需调整措辞或分类位置，请随时告知。
