### PR TITLE
在数据源分类中加入 edgar-geo-revenue

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 * [FXMacroData](https://fxmacrodata.com) - 实时外汇宏观经济数据 API，提供 18 种货币的央行公告、利率、通胀、就业和 GDP 数据。支持 MCP 服务器和 OAuth。[GitHub](https://github.com/fxmacrodata/fxmacrodata) | [PyPI](https://pypi.org/project/fxmacrodata/)
 * [Adanos Market Sentiment API](https://adanos.org/) - 股票市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 trending tickers、buzz scores 和情绪指标。
 * [13F Insight](https://13finsight.com) - AI 驱动的美国机构持仓追踪平台，覆盖 380K+ 13F 持仓报告、480K+ 13D/G 激进投资者申报和 437万+ Form 4 内部人交易数据，内嵌 AI Agent 支持自然语言查询。
+* [edgar-geo-revenue](https://github.com/Metricshour/edgar-geo-revenue) - 从 SEC EDGAR 10-K 中提取公司收入的地理分布（国家/地区拆分），纯 Python，无需 API Key。[PyPI](https://pypi.org/project/edgar-geo-revenue/)
 * [finlight](https://finlight.me/) - 实时财经新闻 API，聚焦全球金融、地缘政治与市场新闻，提供 REST 和 WebSocket 接口，内置实体识别与情绪分析。[GitHub](https://github.com/jubeiargh/finlight-client-py) | [PyPI](https://pypi.org/project/finlight-client/)
 * [stock-analysis](https://github.com/AdvancingTitans/stock-analysis) - 面向 A股、港股、美股和基金的证据驱动复盘 CLI，可生成 Markdown 报告和 JSON Evidence Packs，便于 AI Agent 审计与复用。
 * [0xArchive](https://0xarchive.io/) - 提供 Hyperliquid 和 Lighter 的实时与历史市场数据 API，支持 REST 和 WebSocket。


### PR DESCRIPTION
## 简介
在 **数据源** 中加入 [edgar-geo-revenue](https://github.com/Metricshour/edgar-geo-revenue)。

- 从 SEC EDGAR **10-K** 提取公司收入的**地理分布**（国家/地区）
- 纯 Python，**无需 API Key**
- 安装：`pip install edgar-geo-revenue`
- PyPI：https://pypi.org/project/edgar-geo-revenue/
- 文档：https://metricshour.github.io/edgar-geo-revenue/

放在 13F Insight 附近，同属美国 SEC 公开披露数据工具。