### PR TITLE
Add Manifold-BT to 回测 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 
 ## 回测
 * [Zipline](https://github.com/quantopian/zipline) - 一个Python的回测框架
+* [Manifold-BT](https://github.com/manifoldbt/manifoldbt) - High-performance Rust-powered Python backtesting engine (vectorized signals + realistic fills; sweeps / walk-forward / Monte Carlo)
 * [pyalgotrade](https://github.com/gbeced/pyalgotrade) - 一个Python的事件驱动回测框架
 * [pyalgotrade-cn](https://github.com/Yam-cn/pyalgotrade-cn) - Pyalgotrade-cn在原版pyalgotrade的基础上加入了A股历史行情回测，并整合了tushare提供实时行情。
 * [ricequant/rqalpha](https://github.com/ricequant/rqalpha) - RQalpha: Ricequant 开源的基于Python的回测引擎


### PR DESCRIPTION
在「回测」一节加入 Manifold-BT（Zipline 之后）。

- Rust 核心 + Python API（`pip install manifoldbt`）
- 向量化信号 + 真实成交建模（fees / slippage / look-ahead）
- 参数扫描、walk-forward、Monte Carlo
- 文档与示例：https://www.manifoldbt.com

非归档项目，列表中无重复项。