### PR TITLE
Add manifoldbt to 回测 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 * [finclaw](https://github.com/NeuZhou/finclaw) - AI驱动的量化交易引擎，484个内置alpha因子，遗传算法策略进化，walk-forward回测和模拟交易
 * [TraderHarness](https://github.com/HephaestLab/TraderHarness) - 抗数据污染的A股LLM交易Agent回测环境：全出口时点掩码、日期/公司确定性匿名化、分钟级渐进撮合、指纹回放与全保真轨迹导出（SFT数据合成）
 * [dsh-quant](https://github.com/pengpengyi92/dsh-quant) - Agent-native 量化研究工具箱（DeepSeek Harness 插件）：46 工具 · 6 域（数据/因子/ML/风控/执行），免费行情三市场（加密/A股/美股）+ 渠道知识库 + 多标的并行研究流水线；npm 安装，215 测试，60+ 次自动发布
+* [manifoldbt](https://github.com/manifoldbt/manifoldbt) - Rust 内核 + Python API 的回测引擎：向量化表达式策略、参数扫描、walk-forward 与蒙特卡罗，可选 GPU 加速
 
 ## 交易API
 * [上海期货信息技术有限公司CTP API](http://www.sfit.com.cn/5_2_DocumentDown.htm) - 期货交易所提供的API


### PR DESCRIPTION
在 `## 回测` 一节加入 [manifoldbt](https://github.com/manifoldbt/manifoldbt)。

Rust 内核 + Python API 的回测引擎，策略以向量化表达式书写（`when(rsi(close,14)<20, ...)`），内置参数扫描、walk-forward 和蒙特卡罗，CUDA 加速为可选项，缺少 GPU 时自动回落到 CPU。已发布到 PyPI（`pip install manifoldbt`），提供 cp39-abi3 轮子，覆盖 Python 3.9 至 3.14 的 macOS、Linux 与 Windows，无需编译器。

许可证为 Apache 2.0 + Commons Clause，属于 source-available 而非严格意义上的开源，先在此说明。本人为该项目作者。
