### PR TITLE
在数据源分类中加入 itch-book

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 * [finlight](https://finlight.me/) - 实时财经新闻 API，聚焦全球金融、地缘政治与市场新闻，提供 REST 和 WebSocket 接口，内置实体识别与情绪分析。[GitHub](https://github.com/jubeiargh/finlight-client-py) | [PyPI](https://pypi.org/project/finlight-client/)
 * [stock-analysis](https://github.com/AdvancingTitans/stock-analysis) - 面向 A股、港股、美股和基金的证据驱动复盘 CLI，可生成 Markdown 报告和 JSON Evidence Packs，便于 AI Agent 审计与复用。
 * [0xArchive](https://0xarchive.io/) - 提供 Hyperliquid 和 Lighter 的实时与历史市场数据 API，支持 REST 和 WebSocket。
+* [itch-book](https://github.com/groovg/itch-book) - NASDAQ TotalView-ITCH 5.0 逐笔行情解析与订单簿重建，C++23 核心，pip 安装；命令行工具下载并校验 emi.nasdaq.com 免费全天数据，输出 BBO、成交、逐笔委托和深度 Parquet 表。[PyPI](https://pypi.org/project/itch-book/)
 
 ## 数据库
 


### PR DESCRIPTION
在 `数据源` 分类中加入 itch-book。

* **链接：** https://github.com/groovg/itch-book
* **简介：** NASDAQ TotalView-ITCH 5.0 逐笔行情解析与订单簿重建，C++23 核心，`pip install itch-book`；命令行工具可下载并校验 emi.nasdaq.com 的免费全天数据文件，输出 BBO、成交、逐笔委托和深度 Parquet 表。一个交易日（2.68 亿条消息）约一分钟转换完成，订单簿与 Databento XNAS.ITCH 数据做过交叉验证。
* **许可：** MIT，开源，持续维护。
